### PR TITLE
API Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Unreleased
+
+- *BREAKING CHANGE*: `scrub` and `normalize` have been renamed to
+  `strip` and `collapse` based on usage and feedback
+  ([#1](https://github.com/jmdeldin/scrubba/pull/1)). The new way to
+  declare which attributes you want to strip/collapse whitespace from
+  is:
+
+      scrub :some_attr, strip: true, collapse: true
+
 # 0.2.0 (2015-08-29)
 
 - *BREAKING CHANGE*: Switched from `extend` to `include` for consistency

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ end
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/jmdeldin/scrubba.
 
-Protip: If you use Emacs, insert Unicode spaces in your test data with <kbd>M-x insert-char</kbd> and verify it with <kbd>M-x describe-char</kbd>.
+Protip: If you use Emacs, insert a Unicode space in your test data with <kbd>M-x insert-char</kbd> and verify it with <kbd>M-x describe-char</kbd>.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ end
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/jmdeldin/scrubba.
 
+Protip: If you use Emacs, insert Unicode spaces in your test data with <kbd>M-x insert-char</kbd> and verify it with <kbd>M-x describe-char</kbd>.
+
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Standalone:
 require "scrubba"
 
 some_str = " foo \t bar "
-Scrubba.scrub(some_str) #=> "foo \t bar"
-Scrubba.normalize(some_str) #=> " foo bar "
+Scrubba.strip(some_str) #=> "foo \t bar"
+Scrubba.collapse(some_str) #=> " foo bar "
 ```
 
 In an ActiveRecord model:
@@ -40,8 +40,8 @@ require "scrubba"
 class Post < ActiveRecord::Base
   include Scrubba::ActiveMethods
 
-  strip :title, :body
-  normalize :title
+  scrub :title, :slug, strip: true
+  scrub :body, collapse: true
 end
 ```
 

--- a/lib/scrubba.rb
+++ b/lib/scrubba.rb
@@ -7,7 +7,7 @@ module Scrubba
   #
   # @param [String] str
   # @return [String]
-  def self.scrub(str)
+  def self.strip(str)
     str.gsub(/(\A[[:space:]]+|[[:space:]]+\z)/, "") if str
   end
 

--- a/lib/scrubba.rb
+++ b/lib/scrubba.rb
@@ -15,7 +15,7 @@ module Scrubba
   #
   # @param [String] str
   # @return [String]
-  def self.normalize(str)
+  def self.collapse(str)
     str.gsub(/[[:space:]]+/, " ") if str
   end
 end

--- a/lib/scrubba/active_methods.rb
+++ b/lib/scrubba/active_methods.rb
@@ -11,8 +11,8 @@ module Scrubba
     end
 
     module ClassMethods
-      def scrub(*keys)
-        before_validation { scrubba_apply(keys, :scrub) }
+      def strip(*keys)
+        before_validation { scrubba_apply(keys, :strip) }
       end
 
       def normalize(*keys)

--- a/lib/scrubba/active_methods.rb
+++ b/lib/scrubba/active_methods.rb
@@ -15,8 +15,8 @@ module Scrubba
         before_validation { scrubba_apply(keys, :strip) }
       end
 
-      def normalize(*keys)
-        before_validation { scrubba_apply(keys, :normalize) }
+      def collapse(*keys)
+        before_validation { scrubba_apply(keys, :collapse) }
       end
     end
   end

--- a/lib/scrubba/active_methods.rb
+++ b/lib/scrubba/active_methods.rb
@@ -4,19 +4,19 @@ module Scrubba
       base.extend(ClassMethods)
     end
 
-    def scrubba_apply(keys, func)
-      keys.each do |k|
-        self[k] = Scrubba.public_send(func, self[k]) if self[k].present?
-      end
+    def scrubba_apply(key, func)
+      self[key] = Scrubba.public_send(func, self[key]) if self[key].present?
     end
 
     module ClassMethods
-      def strip(*keys)
-        before_validation { scrubba_apply(keys, :strip) }
-      end
-
-      def collapse(*keys)
-        before_validation { scrubba_apply(keys, :collapse) }
+      # Strip and/or collapse whitespace from given attributes.
+      def scrub(*keys, strip: false, collapse: false)
+        before_validation do
+          keys.each do |k|
+            scrubba_apply(k, :strip) if strip
+            scrubba_apply(k, :collapse) if collapse
+          end
+        end
       end
     end
   end

--- a/test/scrubba/active_methods_test.rb
+++ b/test/scrubba/active_methods_test.rb
@@ -7,10 +7,10 @@ class FakeModel
   include ActiveModel::Validations::Callbacks
   include Scrubba::ActiveMethods
 
-  strip :title, :body
-  normalize :title
+  scrub :title, :slug, strip: true, collapse: true
+  scrub :body, strip: true
 
-  attr_accessor :title, :body
+  attr_accessor :title, :body, :slug
 
   # these methods are provided by ActiveRecord & ActiveAttr -- implemented
   # here so we don't need another dev dependency
@@ -25,13 +25,14 @@ end
 
 class ActiveMethodsTest < Minitest::Test
   def test_strip
-    f = FakeModel.new(title: " foo bar ", body: "blah blah blah. ")
+    f = FakeModel.new(title: " foo bar ", slug: " space", body: "blah blah. ")
     f.valid?
     assert_equal "foo bar", f.title
-    assert_equal "blah blah blah.", f.body
+    assert_equal "space", f.slug
+    assert_equal "blah blah.", f.body
   end
 
-  def test_normalize
+  def test_collapse
     f = FakeModel.new(title: " foo \t\n   bar ", body: "blah\n\nblah. ")
     f.valid?
     assert_equal "foo bar", f.title

--- a/test/scrubba/active_methods_test.rb
+++ b/test/scrubba/active_methods_test.rb
@@ -7,7 +7,7 @@ class FakeModel
   include ActiveModel::Validations::Callbacks
   include Scrubba::ActiveMethods
 
-  scrub :title, :body
+  strip :title, :body
   normalize :title
 
   attr_accessor :title, :body

--- a/test/scrubba_test.rb
+++ b/test/scrubba_test.rb
@@ -13,7 +13,14 @@ class ScrubbaScrubTest < Minitest::Test
 
   def test_spaces
     assert_equal "foo", Scrubba.scrub("  foo  \n\t")
+  end
+
+  def test_unicode_non_breaking_space
     assert_equal "foo", Scrubba.scrub(" foo ")
+  end
+
+  def test_unicode_em_space
+    assert_equal "foo", Scrubba.scrub(" foo  ")
   end
 
   def test_orig_str_ref

--- a/test/scrubba_test.rb
+++ b/test/scrubba_test.rb
@@ -30,16 +30,16 @@ class ScrubbaScrubTest < Minitest::Test
   end
 end
 
-class ScrubbaNormalizeTest < Minitest::Test
+class ScrubbaCollapseTest < Minitest::Test
   def test_nil
-    assert_nil Scrubba.normalize(nil)
+    assert_nil Scrubba.collapse(nil)
   end
 
-  def test_normalizes_newlines
-    assert_equal " foo bar", Scrubba.normalize(" \t\n\r foo \n \n bar")
+  def test_collapses_newlines
+    assert_equal " foo bar", Scrubba.collapse(" \t\n\r foo \n \n bar")
   end
 
-  def test_normalizes_unicode_spaces
-    assert_equal " foo bar", Scrubba.normalize(" foo bar")
+  def test_collapses_unicode_spaces
+    assert_equal " foo bar", Scrubba.collapse(" foo bar")
   end
 end

--- a/test/scrubba_test.rb
+++ b/test/scrubba_test.rb
@@ -4,28 +4,28 @@ require "active_model"
 
 class ScrubbaScrubTest < Minitest::Test
   def test_nil
-    assert_nil Scrubba.scrub(nil)
+    assert_nil Scrubba.strip(nil)
   end
 
   def test_empty_str
-    assert_equal "", Scrubba.scrub("")
+    assert_equal "", Scrubba.strip("")
   end
 
   def test_spaces
-    assert_equal "foo", Scrubba.scrub("  foo  \n\t")
+    assert_equal "foo", Scrubba.strip("  foo  \n\t")
   end
 
   def test_unicode_non_breaking_space
-    assert_equal "foo", Scrubba.scrub(" foo ")
+    assert_equal "foo", Scrubba.strip(" foo ")
   end
 
   def test_unicode_em_space
-    assert_equal "foo", Scrubba.scrub(" foo  ")
+    assert_equal "foo", Scrubba.strip(" foo  ")
   end
 
   def test_orig_str_ref
     str = " foo bar "
-    assert_equal "foo bar", Scrubba.scrub(str)
+    assert_equal "foo bar", Scrubba.strip(str)
     assert_equal " foo bar ", str
   end
 end


### PR DESCRIPTION
- [x] Rename `scrub` to `strip`: `scrub` is rather opaque -- we're really just stripping excess space
  from a string.
- [x] Rename `normalize` to `collapse`: `normalize` was too vague.
- [x] Shove all the Active\* functionality into a `scrub` module
- [x] Update Changelog
